### PR TITLE
Fixed bad import reference.  Bumped version.

### DIFF
--- a/meta_definitions/device/definitions.py
+++ b/meta_definitions/device/definitions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from metrics import *
+from .metrics import *
 
 ALL = {
     META_ACTIVE_CURRENT: {

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def requirements():
 
 setuptools.setup(
     name="meta-definitions",
-    version="1.0.3",
+    version="1.0.4",
     author="Gooee",
     description="Meta Definitions used in the Gooee Cloud",
     install_requires=requirements(),


### PR DESCRIPTION
I've realized that this import needed to be relative.  I've tested this change by referencing the commit in `cloud-api` `requirements.txt` on my EPH stack.