### PR TITLE
GC-10026 - Workaround: Investigate what it would take to push PG Sensor online/offline status

### DIFF
--- a/meta_definitions/device/definitions.py
+++ b/meta_definitions/device/definitions.py
@@ -1803,7 +1803,7 @@ ALL = {
         "display_name": "Is Online",
         "json_schema": {"type": "boolean"},
         "value_display_name": {"type": "enum", "true": "Online", "false": "Offline"},
-        "groups": ["~operational"],
+        "groups": ["~operational", "~rule_trigger"],
     },
     META_ISOLATION_DAMPER_ENABLE: {
         "display_name": "Isolation Damper Enable",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def requirements():
 
 setuptools.setup(
     name="meta-definitions",
-    version="1.0.9",
+    version="1.0.10",
     author="Gooee",
     description="Meta Definitions used in the Gooee Cloud",
     install_requires=requirements(),


### PR DESCRIPTION
- Added `is_online` to the `~rule_trigger` Meta Group.
- Bumped version.

Related PR(s):
https://github.com/GooeeIOT/cloud-api/pull/2415